### PR TITLE
Fix issue with managed dashes used in Comparison

### DIFF
--- a/aircraft/airbus-a32x/glareshield/fcu/FCU.mcc
+++ b/aircraft/airbus-a32x/glareshield/fcu/FCU.mcc
@@ -4,7 +4,7 @@
     <config guid="09f954ee-e879-4da9-adf3-130bbbfddf8d">
       <active>true</active>
       <description>AP1 On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_1_ACTIVE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="AP1 LED" pinBrightness="255" />
@@ -23,7 +23,7 @@
     <config guid="aa28640d-8ef5-436b-aa05-40a2adad490a">
       <active>true</active>
       <description>AP2 On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_2_ACTIVE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="AP2 LED" pinBrightness="255" />
@@ -42,7 +42,7 @@
     <config guid="3791a47a-7a03-4009-8ae3-e57c56070e70">
       <active>true</active>
       <description>ATHR On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOTHRUST_STATUS)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="ATHR LED" pinBrightness="255" />
@@ -61,7 +61,7 @@
     <config guid="9d10f89f-6b09-4b8d-95aa-ee064b6d7e34">
       <active>true</active>
       <description>Annunciator Birghtness</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_OVHD_INTLT_ANN)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="Annunciators Brt" pinBrightness="255" pinPwm="True" />
@@ -80,7 +80,7 @@
     <config guid="f732c6e4-f63d-4aa5-b331-96cd00643f79">
       <active>true</active>
       <description>Overhead Annuciator Mode</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_OVHD_INTLT_ANN)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -97,7 +97,7 @@
     <config guid="072e704f-52c4-4f61-aacb-0076c3fd5c83">
       <active>true</active>
       <description>Speed Selected (Knots)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_SPEED_SELECTED, Number)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="3,4,5" />
@@ -121,9 +121,9 @@
     <config guid="28f39df1-2956-449d-80cd-266781de370e">
       <active>true</active>
       <description>Speed Selected (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="---" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'---'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="3,4,5" />
         <preconditions>
           <precondition type="config" active="true" ref="b2d8fd50-d1b4-4a4c-83a8-1b538dcb348a" operand="=" value="1" logic="and" />
@@ -144,7 +144,7 @@
     <config guid="d9578f1a-1671-4496-b30c-0228f1e79648">
       <active>true</active>
       <description>Speed Selected (Off)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="   " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="3,4,5" />
@@ -165,7 +165,7 @@
     <config guid="dd8c2b0d-3649-4c0b-92ab-5f263f0e3435">
       <active>true</active>
       <description>Speed Selected (Test)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="888" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="3,4,5" ledDecimalPoints="3,4,5" />
@@ -187,7 +187,7 @@
     <config guid="08ebcd03-f797-48e6-8c41-0f10e8c5282b">
       <active>true</active>
       <description>Speed Selected (Mach)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:AUTOPILOT MACH HOLD VAR, Number) 100 * near" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="3,4,5" ledDecimalPoints="5" />
@@ -211,7 +211,7 @@
     <config guid="0368e068-c05b-41dc-b24d-46897ea73cc9">
       <active>true</active>
       <description>Heading Selected</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_HEADING_SELECTED) near" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2" />
@@ -234,9 +234,9 @@
     <config guid="5ed37a84-d46b-4d85-a429-e757657ac85d">
       <active>true</active>
       <description>Heading Selected (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="---" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'---'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2" />
         <preconditions>
           <precondition type="config" active="true" ref="95cc2a96-477d-4411-b887-4d3959902ed7" operand="=" value="1" logic="and" />
@@ -257,7 +257,7 @@
     <config guid="42d70d2f-50ba-4d71-b9af-05e3c82ca595">
       <active>true</active>
       <description>Heading Selected (Off)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="   " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2" />
@@ -278,7 +278,7 @@
     <config guid="cc60d580-6d3a-4e4e-a204-b2bd84b81fc2">
       <active>true</active>
       <description>Heading Selected (Test)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="888" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="1" ledModuleSize="6" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2" ledDecimalPoints="0,1,2" />
@@ -300,7 +300,7 @@
     <config guid="a51081d3-25a2-4ceb-b7af-ffcbecf84051">
       <active>true</active>
       <description>Display Brightness</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="FSUIPC" offset="0x0000" offsetType="Integer" size="1" mask="0x00FF" bcdMode="False" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="Display Brt" pinBrightness="255" pinPwm="True" />
@@ -319,7 +319,7 @@
     <config guid="b0eb9dfd-3f39-403e-86eb-506ab642554e">
       <active>true</active>
       <description>Altitude Selected</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:AUTOPILOT ALTITUDE LOCK VAR:3, Feet)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="2" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2,3,4" />
@@ -341,7 +341,7 @@
     <config guid="70f80357-c769-475f-9d72-10916172f754">
       <active>true</active>
       <description>Altitude Selected (Off)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="     " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="2" ledModuleSize="5" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2,3,4" />
@@ -362,7 +362,7 @@
     <config guid="720eff8e-3718-4d1e-807a-0aac619f7b96">
       <active>true</active>
       <description>Altitude Selected (Test)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="88888" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="2" ledModuleSize="5" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1,2,3,4" />
@@ -384,7 +384,7 @@
     <config guid="8263598d-1085-435d-a5f1-ce911b73259e">
       <active>true</active>
       <description>VS Rate</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_VS_SELECTED)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="2,3" />
@@ -407,9 +407,9 @@
     <config guid="da428c78-b4b1-4e3f-9105-c1ab27aaa6ff">
       <active>true</active>
       <description>VS Rate (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="--" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'--'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="2,3" />
         <preconditions>
           <precondition type="config" active="true" ref="ad4a12a9-af53-484e-ace3-47934568bb05" operand="=" value="1" logic="and" />
@@ -431,7 +431,7 @@
     <config guid="941b515a-2eff-4796-acb8-5aa15594a0f2">
       <active>true</active>
       <description>VS Small Zeros</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="oo" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1" />
@@ -455,7 +455,7 @@
     <config guid="d55d2519-7282-459c-a785-0bd018529091">
       <active>true</active>
       <description>VS Small Zeros (Off)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="  " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1" />
@@ -476,7 +476,7 @@
     <config guid="2a4b31e0-0212-4ac4-bdb0-a0f21bd0b8d5">
       <active>true</active>
       <description>VS Small Zeros (Test)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="88" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1" />
@@ -498,9 +498,9 @@
     <config guid="2a76beeb-e260-4d8a-9725-ee4efb40ed95">
       <active>true</active>
       <description>VS Small Zeros (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="--" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'--'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="0,1" />
         <preconditions>
           <precondition type="config" active="true" ref="ad4a12a9-af53-484e-ace3-47934568bb05" operand="=" value="1" logic="and" />
@@ -522,9 +522,9 @@
     <config guid="35d3e1ef-f63a-4b9d-967b-42749cb59a1f">
       <active>true</active>
       <description>VS Sign</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_VS_SELECTED)" />
-        <comparison active="True" value="0" operand="&lt;" ifValue="-" elseValue=" " />
+        <comparison active="True" value="0" operand="&lt;" ifValue="'-'" elseValue=" " />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="4" />
         <preconditions>
           <precondition type="config" active="true" ref="ad4a12a9-af53-484e-ace3-47934568bb05" operand="=" value="1" logic="and" />
@@ -546,9 +546,9 @@
     <config guid="8ccdc53b-fcdc-49f0-a590-f7346ce8bf24">
       <active>true</active>
       <description>FPA Sign</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_FPA_SELECTED)" />
-        <comparison active="True" value="0" operand="&lt;" ifValue="-" elseValue=" " />
+        <comparison active="True" value="0" operand="&lt;" ifValue="'-'" elseValue=" " />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="4" />
         <preconditions>
           <precondition type="config" active="true" ref="ad4a12a9-af53-484e-ace3-47934568bb05" operand="=" value="1" logic="and" />
@@ -571,9 +571,9 @@
     <config guid="9a7b17ce-388e-4b11-95ee-813975b11731">
       <active>true</active>
       <description>FPA Sign (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="-" elseValue=" " />
+        <comparison active="True" value="0" operand="=" ifValue="'-'" elseValue=" " />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="4" />
         <preconditions>
           <precondition type="config" active="true" ref="ad4a12a9-af53-484e-ace3-47934568bb05" operand="=" value="1" logic="and" />
@@ -595,9 +595,9 @@
     <config guid="67711033-f49a-442e-9ca7-e25a3f94ab9f">
       <active>true</active>
       <description>VS Sign (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_VS_SELECTED)" />
-        <comparison active="True" value="0" operand="=" ifValue="-" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'-'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="4" />
         <preconditions>
           <precondition type="config" active="true" ref="ad4a12a9-af53-484e-ace3-47934568bb05" operand="=" value="1" logic="and" />
@@ -619,7 +619,7 @@
     <config guid="3c7bdc99-8fd0-4b77-bf83-e67dfbe335f8">
       <active>true</active>
       <description>VS Sign (Off)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue=" " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="4" />
@@ -640,7 +640,7 @@
     <config guid="19b94003-6de2-4567-9802-e8790108a51b">
       <active>true</active>
       <description>VS Sign (Test)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="8" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="4" />
@@ -662,7 +662,7 @@
     <config guid="a45fc3e2-5139-4856-9f30-87e009024014">
       <active>true</active>
       <description>VS Rate (Off)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="  " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="2,3" />
@@ -683,7 +683,7 @@
     <config guid="f21176f4-e05e-4a4f-903d-930caf0ee83d">
       <active>true</active>
       <description>VS Rate (Test)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="88" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="False" ledBrightnessRef="727fe4ce-6e0b-47f6-9387-0869614dc850" ledPaddingChar="0" ledDigits="2,3" ledDecimalPoints="3" />
@@ -705,7 +705,7 @@
     <config guid="5174e183-3494-4fae-ab55-013f35aa5a7f">
       <active>true</active>
       <description>Speed Mode is Mach</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:AUTOPILOT MANAGED SPEED IN MACH, Bool)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -724,7 +724,7 @@
     <config guid="4f0aabfd-4f80-42b4-82b6-179e2c03e55c">
       <active>true</active>
       <description>Speed Dot</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_SPD_MANAGED_DOT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="SPD Dot" pinBrightness="255" />
@@ -743,7 +743,7 @@
     <config guid="95cc2a96-477d-4411-b887-4d3959902ed7">
       <active>true</active>
       <description>Heading is Dashes</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_HDG_MANAGED_DASHES)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -762,7 +762,7 @@
     <config guid="b2d8fd50-d1b4-4a4c-83a8-1b538dcb348a">
       <active>true</active>
       <description>Speed is Dashes</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_SPD_MANAGED_DASHES)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -781,7 +781,7 @@
     <config guid="b87ecc11-74d6-44d8-b9d5-d08219975eae">
       <active>true</active>
       <description>FCU Display Brightness (Raw)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:LIGHT POTENTIOMETER:87, PERCENT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -800,7 +800,7 @@
     <config guid="727fe4ce-6e0b-47f6-9387-0869614dc850">
       <active>true</active>
       <description>FCU Display Brightness (LED Modules)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:LIGHT POTENTIOMETER:87, PERCENT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -823,7 +823,7 @@
     <config guid="5d2e79f1-576b-45a4-ac61-7abb45ee5135">
       <active>true</active>
       <description>FCU Display Brightness (LEDs)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:LIGHT POTENTIOMETER:87, PERCENT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="Display Brt" pinBrightness="255" pinPwm="True" />
@@ -847,9 +847,9 @@
     </config>
     <config guid="a713e76f-55b1-4cf2-8b8d-c7098a0cbed3">
       <active>true</active>
-      <description>ESS Bus is Powered (DC)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <source type="SimConnect" VarType="CODE" Value="(L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED, bool)" />
+      <description>ESS Bus is Powered (AC)</description>
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="CODE" Value="(L:A32NX_ELEC_AC_ESS_BUS_IS_POWERED, bool)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
         <preconditions />
@@ -867,7 +867,7 @@
     <config guid="b701dce3-2a40-4225-8417-eaf7edd3dae3">
       <active>true</active>
       <description>Altitude is Managed</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_ALT_MANAGED)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -886,7 +886,7 @@
     <config guid="ad4a12a9-af53-484e-ace3-47934568bb05">
       <active>true</active>
       <description>Display is On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -905,7 +905,7 @@
     <config guid="32ceadcc-9287-4b59-b488-f748d45bb79e">
       <active>true</active>
       <description>Heading Dot</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_HDG_MANAGED_DOT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="HDG Dot" pinBrightness="255" />
@@ -924,7 +924,7 @@
     <config guid="4a93cc79-ffa9-4f72-9bc4-a7fa666c1196">
       <active>true</active>
       <description>Altitude Dot</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_ALT_MANAGED)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="VS Dot" pinBrightness="255" />
@@ -943,8 +943,8 @@
     <config guid="ba800869-5946-4c90-b945-7aba4b5fc277">
       <active>true</active>
       <description>LED SPD</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <source type="SimConnect" VarType="CODE" Value="" />
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED SPD" pinBrightness="255" />
         <preconditions />
@@ -962,8 +962,8 @@
     <config guid="9db94dc6-f7b0-4d16-8fa4-051afe32c07a">
       <active>true</active>
       <description>LED MACH</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <source type="SimConnect" VarType="CODE" Value="" />
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED MACH" pinBrightness="255" />
         <preconditions />
@@ -981,7 +981,7 @@
     <config guid="84ead911-5dac-429f-a9e7-17e96775801f">
       <active>true</active>
       <description>LEDs HDG Mode</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_TRK_FPA_MODE_ACTIVE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED HDG|LED MID HDG|LED MID VS|LED VS" pinBrightness="255" />
@@ -1000,7 +1000,7 @@
     <config guid="52666007-71d0-4372-a321-662489540cba">
       <active>true</active>
       <description>LEDs TRK Mode</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_TRK_FPA_MODE_ACTIVE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED TRK|LED MID TRK|LED MID FPA|LED FPA" pinBrightness="255" />
@@ -1019,7 +1019,7 @@
     <config guid="cac393d1-1dc8-45a0-acd3-e7281d46255c">
       <active>true</active>
       <description>Integral Lighting Brightness (Raw)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:LIGHT POTENTIOMETER:84, PERCENT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -1038,7 +1038,7 @@
     <config guid="6c8df8bc-28ef-421c-82f3-fcf9acb2449d">
       <active>true</active>
       <description>Integral Lighting Brightness (Backlight LEDs)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(A:LIGHT POTENTIOMETER:84, PERCENT)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="Backlight Brt" pinBrightness="255" pinPwm="True" />
@@ -1061,7 +1061,7 @@
     <config guid="4ad7003d-7cf3-426f-94ac-8d87d412c55a">
       <active>true</active>
       <description>LED LAT</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED LAT" pinBrightness="255" />
@@ -1080,7 +1080,7 @@
     <config guid="c8e864ef-cdbe-452f-b9d8-63edaabbd4bd">
       <active>true</active>
       <description>VS is Managed</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_VS_MANAGED)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="" serial="-" trigger="normal" pin="" pinBrightness="255" />
@@ -1099,7 +1099,7 @@
     <config guid="0f81d867-85a4-4ee7-bd5b-376cf2de0096">
       <active>true</active>
       <description>LOC On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_LOC_MODE_ACTIVE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED LOC" pinBrightness="255" />
@@ -1118,7 +1118,7 @@
     <config guid="541f9255-9ae4-4159-99f1-aa7415161caa">
       <active>true</active>
       <description>EXPED On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FMA_EXPEDITE_MODE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED EXPED" pinBrightness="255" />
@@ -1137,7 +1137,7 @@
     <config guid="16cba28b-8e93-4367-84d7-332d9945b82b">
       <active>true</active>
       <description>APPR On</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_FCU_APPR_MODE_ACTIVE)" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Pin" serial="FCU/ SN-769-a6a" trigger="normal" pin="LED APPR" pinBrightness="255" />
@@ -1156,7 +1156,7 @@
     <config guid="17df4b9b-a4af-48b1-822c-69300c4e0651">
       <active>true</active>
       <description>FPA Rate</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="CODE" Value="(L:A32NX_AUTOPILOT_FPA_SELECTED) 10 * near" />
         <comparison active="False" value="" operand="" ifValue="" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledPaddingChar="0" ledDigits="2,3" ledDecimalPoints="3" />
@@ -1179,9 +1179,9 @@
     <config guid="f74e259a-775f-4020-9982-f8018bfb53a5">
       <active>true</active>
       <description>FPA Rate (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="--" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'--'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="True" ledPaddingChar="0" ledDigits="2,3" />
         <preconditions>
           <precondition type="config" active="true" ref="52666007-71d0-4372-a321-662489540cba" operand="=" value="1" logic="and" />
@@ -1202,7 +1202,7 @@
     <config guid="50dea196-c69e-4adf-b7fb-15ca56bdeb4d">
       <active>true</active>
       <description>FPA Rate Blanks</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
         <comparison active="True" value="0" operand="=" ifValue="  " elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="False" ledPaddingChar="0" ledDigits="0,1" />
@@ -1225,9 +1225,9 @@
     <config guid="c98bfd35-27ec-468d-9b44-cd77235bf8f5">
       <active>true</active>
       <description>FPA Rate Blanks (Dashes)</description>
-      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.OutputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <source type="SimConnect" VarType="LVAR" Value="" />
-        <comparison active="True" value="0" operand="=" ifValue="--" elseValue="" />
+        <comparison active="True" value="0" operand="=" ifValue="'--'" elseValue="" />
         <display type="Display Module" serial="FCU/ SN-769-a6a" trigger="normal" ledAddress="LED Display" ledConnector="3" ledModuleSize="5" ledPadding="False" ledPaddingChar="0" ledDigits="0,1" />
         <preconditions>
           <precondition type="config" active="true" ref="52666007-71d0-4372-a321-662489540cba" operand="=" value="1" logic="and" />
@@ -1250,7 +1250,7 @@
     <config guid="843d359f-f16d-4587-a261-3b2a9a803c26">
       <active>true</active>
       <description>AP1</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="AP1" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="AP1" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_AP_1_PUSH)" />
           <onRelease />
@@ -1269,7 +1269,7 @@
     <config guid="c5805349-e84b-434b-86e9-228efbc99263">
       <active>true</active>
       <description>AP2</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="AP2" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="AP2" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_AP_2_PUSH)" />
           <onRelease />
@@ -1288,7 +1288,7 @@
     <config guid="7a3a04ae-decb-42f9-8fc8-154cb4db3b97">
       <active>true</active>
       <description>ATHR</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ATHR" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ATHR" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_ATHR_PUSH)" />
           <onRelease />
@@ -1307,7 +1307,7 @@
     <config guid="0bff645c-0d4a-46ad-85cc-2b6dbf03febe">
       <active>true</active>
       <description>SPD MACH</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD MACH" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD MACH" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_SPD_MACH_TOGGLE_PUSH)" />
           <onRelease />
@@ -1326,7 +1326,7 @@
     <config guid="2a997fcb-972a-4a49-9c7e-3986c3c4e7fa">
       <active>true</active>
       <description>HDG TRK</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG TRK" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG TRK" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_TRK_FPA_TOGGLE_PUSH)" />
           <onRelease />
@@ -1345,7 +1345,7 @@
     <config guid="b358a408-2793-42d0-8fed-4986c2842cf7">
       <active>true</active>
       <description>Speed Knob</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <encoder>
           <onLeft type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_SPD_DEC)" />
           <onLeftFast />
@@ -1366,7 +1366,7 @@
     <config guid="730b86ce-f58c-40ee-9dfa-e90d4fc56180">
       <active>true</active>
       <description>Speed Push</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_SPD_PUSH)" />
           <onRelease />
@@ -1385,7 +1385,7 @@
     <config guid="2e8891cc-0c02-47fc-8b53-71458709daf1">
       <active>true</active>
       <description>Speed Pull</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="SPD Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_SPD_PULL)" />
           <onRelease />
@@ -1404,7 +1404,7 @@
     <config guid="ab579f8b-1465-422e-b497-b8448c260651">
       <active>true</active>
       <description>Heading Knob</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <encoder>
           <onLeft type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_HDG_DEC)" />
           <onLeftFast />
@@ -1425,7 +1425,7 @@
     <config guid="32846436-9990-4a2c-8aa1-04e2338a9ffe">
       <active>true</active>
       <description>Heading Push</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_HDG_PUSH)" />
           <onRelease />
@@ -1444,7 +1444,7 @@
     <config guid="a5a24be1-1308-4c6c-8636-dc1aebf5cd99">
       <active>true</active>
       <description>Heading Pull</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="HDG Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_HDG_PULL)" />
           <onRelease />
@@ -1463,7 +1463,7 @@
     <config guid="383a79ba-bc15-4402-a7e3-860d2e37158d">
       <active>true</active>
       <description>Altitude Knob</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ALT Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ALT Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <encoder>
           <onLeft type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_ALT_DEC)" />
           <onLeftFast />
@@ -1484,7 +1484,7 @@
     <config guid="fc85c4bf-c621-4813-ad47-2af9821eed3d">
       <active>true</active>
       <description>Altitude Push</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ALT Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ALT Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_ALT_PUSH)" />
           <onRelease />
@@ -1503,7 +1503,7 @@
     <config guid="624abb57-83fc-4c6d-8b59-50ee49df64da">
       <active>true</active>
       <description>Altitude Pull</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ALT Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="ALT Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_ALT_PULL)" />
           <onRelease />
@@ -1522,7 +1522,7 @@
     <config guid="eb9014e8-4f6f-4a99-9d89-c90767e24e30">
       <active>true</active>
       <description>VS Knob</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="VS Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="VS Encoder" type="Encoder" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <encoder>
           <onLeft type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_VS_DEC)" />
           <onLeftFast />
@@ -1543,7 +1543,7 @@
     <config guid="0e14e02f-fef4-454b-a758-5c97deb6d2c1">
       <active>true</active>
       <description>VS Push</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="VS Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="VS Push" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_VS_PUSH)" />
           <onRelease />
@@ -1562,7 +1562,7 @@
     <config guid="d332b046-d9cf-4894-b60c-88032b3f327d">
       <active>true</active>
       <description>VS Pull</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="VS Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="VS Pull" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_VS_PULL)" />
           <onRelease />
@@ -1581,7 +1581,7 @@
     <config guid="13c681c1-a42a-4913-9c99-e89a9dc2c241">
       <active>true</active>
       <description>100/1000 Toggle</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="100-1000 TOG" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="100-1000 TOG" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(L:XMLVAR_Autopilot_Altitude_Increment) 100 == if{ 1000 } els{ 100 } (&gt;L:XMLVAR_Autopilot_Altitude_Increment) " />
           <onRelease />
@@ -1600,7 +1600,7 @@
     <config guid="966fb0f0-db66-460d-b613-90d059f6102d">
       <active>true</active>
       <description>METRIC ALT</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="METRIC ALT" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="METRIC ALT" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(L:A32NX_METRIC_ALT_TOGGLE, bool) ! (&gt;L:A32NX_METRIC_ALT_TOGGLE)" />
           <onRelease />
@@ -1619,7 +1619,7 @@
     <config guid="3b1f6946-2d70-4544-8196-ee47927f4a1f">
       <active>true</active>
       <description>LOC</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="LOC" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="LOC" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_LOC_PUSH)" />
           <onRelease />
@@ -1638,7 +1638,7 @@
     <config guid="8d3a40f5-097b-4855-a944-62fb7ed2f475">
       <active>true</active>
       <description>EXPED</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="EXPED" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="EXPED" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020EventIdInputAction" eventId="A32NX.FCU_EXPED_PUSH" />
           <onRelease type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_EXPED_PUSH)" />
@@ -1657,7 +1657,7 @@
     <config guid="cf8a5c03-bb80-4495-8a74-d5a742010739">
       <active>true</active>
       <description>APPR</description>
-      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="APPR" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+      <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.3.2.0, Culture=neutral, PublicKeyToken=null" serial="FCU/ SN-769-a6a" name="APPR" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
           <onPress type="MSFS2020CustomInputAction" command="(&gt;K:A32NX.FCU_APPR_PUSH)" />
           <onRelease />


### PR DESCRIPTION
Updated the managed dashes representation in the Comparison feature to use single quotes. Without this, the MobiFlight Connector will spam `exception on Ncalcevalute => 0` warnings in the console.